### PR TITLE
replace chalk and log-symbols with ansi-colors

### DIFF
--- a/example.js
+++ b/example.js
@@ -1,9 +1,11 @@
 'use strict';
 const Observable = require('zen-observable');
-const logSymbols = require('log-symbols');
+const colors = require('ansi-colors');
 const delay = require('delay');
 const Listr = require('listr');
 const renderer = require('./');
+
+const success = colors.green(colors.symbols.check);
 
 const tasks = new Listr([
 	{
@@ -62,7 +64,7 @@ const tasks = new Listr([
 
 				delay(2000)
 					.then(() => {
-						observer.next(`${logSymbols.success} 7 passed`);
+						observer.next(`${success} 7 passed`);
 						return delay(2000);
 					})
 					.then(() => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const logUpdate = require('log-update');
-const chalk = require('chalk');
+const colors = require('ansi-colors');
 const figures = require('figures');
 const indentString = require('indent-string');
 const cliTruncate = require('cli-truncate');
@@ -14,7 +14,7 @@ const renderHelper = (tasks, options, level) => {
 
 	for (const task of tasks) {
 		if (task.isEnabled()) {
-			const skipped = task.isSkipped() ? ` ${chalk.dim('[skipped]')}` : '';
+			const skipped = task.isSkipped() ? ` ${colors.dim('[skipped]')}` : '';
 
 			output.push(indentString(` ${utils.getSymbol(task, options)} ${task.title}${skipped}`, level, '  '));
 
@@ -31,7 +31,7 @@ const renderHelper = (tasks, options, level) => {
 
 				if (utils.isDefined(data)) {
 					const out = indentString(`${figures.arrowRight} ${data}`, level, '  ');
-					output.push(`   ${chalk.gray(cliTruncate(out, process.stdout.columns - 3))}`);
+					output.push(`   ${colors.gray(cliTruncate(out, process.stdout.columns - 3))}`);
 				}
 			}
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,11 +1,12 @@
 'use strict';
-const chalk = require('chalk');
-const logSymbols = require('log-symbols');
+const colors = require('ansi-colors');
 const figures = require('figures');
 const elegantSpinner = require('elegant-spinner');
 
-const pointer = chalk.yellow(figures.pointer);
-const skipped = chalk.yellow(figures.arrowDown);
+const pointer = colors.yellow(figures.pointer);
+const skipped = colors.yellow(figures.arrowDown);
+const success = colors.green(colors.symbols.check);
+const error = colors.red(colors.symbols.cross);
 
 exports.isDefined = x => x !== null && x !== undefined;
 
@@ -15,15 +16,15 @@ exports.getSymbol = (task, options) => {
 	}
 
 	if (task.isPending()) {
-		return options.showSubtasks !== false && task.subtasks.length > 0 ? pointer : chalk.yellow(task.spinner());
+		return options.showSubtasks !== false && task.subtasks.length > 0 ? pointer : colors.yellow(task.spinner());
 	}
 
 	if (task.isCompleted()) {
-		return logSymbols.success;
+		return success;
 	}
 
 	if (task.hasFailed()) {
-		return task.subtasks.length > 0 ? pointer : logSymbols.error;
+		return task.subtasks.length > 0 ? pointer : error;
 	}
 
 	if (task.isSkipped()) {

--- a/package.json
+++ b/package.json
@@ -28,12 +28,11 @@
     "rendering"
   ],
   "dependencies": {
-    "chalk": "^1.1.3",
+    "ansi-colors": "^3.0.0",
     "cli-truncate": "^0.2.1",
     "elegant-spinner": "^1.0.1",
     "figures": "^1.7.0",
     "indent-string": "^3.0.0",
-    "log-symbols": "^1.0.2",
     "log-update": "^1.0.2",
     "strip-ansi": "^3.0.1"
   },


### PR DESCRIPTION
This PR replaces chalk and log-symbols with [ansi-colors](https://github.com/doowb/ansi-colors).
`ansi-colors` doesn't have any dependencies and includes the symbols that `listr-update-renderer` already uses.

`ansi-colors` also has notable performance improves when loading and executing compared to `chalk`. See [the benchmarks](https://github.com/doowb/ansi-colors#performance) for more information.

BTW... to run the example, I needed to update to `listr@0.14` but I didn't make that change in the `devDependencies`.