### PR TITLE
Upgrade log update and fix example

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,9 +39,12 @@
   },
   "devDependencies": {
     "delay": "^1.3.1",
-    "listr": "^0.9.0",
+    "listr": "^0.14.2",
     "xo": "*",
     "zen-observable": "^0.4.0"
+  },
+  "peerDependencies": {
+    "listr": "^0.14.2"
   },
   "xo": {
     "esnext": true

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "figures": "^1.7.0",
     "indent-string": "^3.0.0",
     "log-symbols": "^1.0.2",
-    "log-update": "^1.0.2",
+    "log-update": "^2.3.0",
     "strip-ansi": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR upgrades [log-update]https://github.com/sindresorhus/log-update to the latest version to include the fix for SIGINT (https://github.com/sindresorhus/log-update/issues/17).

Additionally, it adds `peerDependencies` field that requires the latest version of lists to fix the example. 

Fixes #8 

Related to https://github.com/sindresorhus/log-update/issues/17

Related to https://github.com/SamVerschueren/listr/issues/85