### PR TITLE
Bump `figures`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"chalk": "^1.1.3",
 		"cli-truncate": "^0.2.1",
 		"elegant-spinner": "^1.0.1",
-		"figures": "^1.7.0",
+		"figures": "^2.0.0",
 		"indent-string": "^3.0.0",
 		"log-symbols": "^1.0.2",
 		"log-update": "^2.3.0",


### PR DESCRIPTION
To match the version used in `listr-verbose-renderer`.