### PR TITLE
Drop node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - '12'
   - '10'
-  - '8'
-  - '6'

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"cli-truncate": "^0.2.1",
 		"elegant-spinner": "^1.0.1",
 		"figures": "^2.0.0",
-		"indent-string": "^3.0.0",
+		"indent-string": "^4.0.0",
 		"log-symbols": "^1.0.2",
 		"log-update": "^2.3.0",
 		"strip-ansi": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"url": "github.com/SamVerschueren"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=10"
 	},
 	"scripts": {
 		"test": "xo"


### PR DESCRIPTION
Node 8 is about to become end-of-life.

By dropping Node@6, this also means you can bump `indent-string` to `4`, which'll allow for better deduplication in projects.