### PR TITLE
Use red text when a task fails

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,11 @@ const renderHelper = (tasks, options, level) => {
 
 				if (utils.isDefined(data)) {
 					const out = indentString(`${figures.arrowRight} ${data}`, level, '  ');
-					output.push(`   ${chalk.gray(cliTruncate(out, process.stdout.columns - 3))}`);
+					if (task.hasFailed()) {
+						output.push(`   ${chalk.red(cliTruncate(out, process.stdout.columns - 3))}`);
+					} else {
+						output.push(`   ${chalk.gray(cliTruncate(out, process.stdout.columns - 3))}`);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes #27 

When a task fails, it prints the last line in red text. For the example file, it looks like:

<img alt="red-error-line" src="https://user-images.githubusercontent.com/190129/94350799-e3684f80-0006-11eb-959b-f5596eaf6d6e.png">
