### PR TITLE
Update strip-ansi dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"indent-string": "^3.0.0",
 		"log-symbols": "^1.0.2",
 		"log-update": "^2.3.0",
-		"strip-ansi": "^3.0.1"
+		"strip-ansi": "^7.0.1"
 	},
 	"devDependencies": {
 		"delay": "^1.3.1",


### PR DESCRIPTION
Hello there!

I am creating this PR to upgrade `strip-ansi` to the latest version (the current version depends on a vulnerable version of `ansi-regex` [link](https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908))