### PR TITLE
Bump strip-ansi from 3.0.1 to 7.1.0 to resolve upstream Snyk error

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"indent-string": "^3.0.0",
 		"log-symbols": "^1.0.2",
 		"log-update": "^2.3.0",
-		"strip-ansi": "^3.0.1"
+		"strip-ansi": "^7.1.0"
 	},
 	"devDependencies": {
 		"delay": "^1.3.1",


### PR DESCRIPTION
To resolve: https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908